### PR TITLE
Change log.info to log.debug onSuccess

### DIFF
--- a/config/Scheduler.cfc
+++ b/config/Scheduler.cfc
@@ -14,8 +14,8 @@ component {
                 } 
             } )
             .onSuccess( function( task, results ) {
-                if ( log.canInfo() ) {
-                    log.info( "Successfully refreshed features", results );
+                if ( log.canDebug() ) {
+                    log.debug( "Successfully refreshed features", results );
                 }
             } )
             .onFailure( function( task, exception ) {
@@ -34,8 +34,8 @@ component {
                 } 
             } )
             .onSuccess( function( task, results ) {
-                if ( log.canInfo() ) {
-                    log.info( "Successfully sent metrics to Unleash features", results );
+                if ( log.canDebug() ) {
+                    log.debug( "Successfully sent metrics to Unleash features", results );
                 }
             } )
             .onFailure( function( task, exception ) {


### PR DESCRIPTION
These onSuccess messages are useful when first setting up the sdk, but once it's working well, these logs every 10/60 seconds become very chatty.