### PR TITLE
Move API Docs build to separate, speedy workflow

### DIFF
--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Generate API Docs
         run: box run-script generateAPIDocs
 

--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -1,0 +1,31 @@
+name: Generate API Docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docbox:
+    name: Generate API Docs
+    runs-on: ubuntu-latest
+    container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
+    steps:
+      - name: Generate API Docs
+        run: box run-script generateAPIDocs
+
+      - name: Setup env.VERSION
+        run: |
+          echo "VERSION=`box package version`" >> $GITHUB_ENV
+          echo ${{ env.VERSION }}
+
+      - name: Upload API Docs to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read
+        env:
+          AWS_S3_BUCKET: "apidocs.ortussolutions.com"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET }}
+          SOURCE_DIR: ".tmp/apidocs"
+          DEST_DIR: "${{ github.repository }}/${{ env.VERSION }}"

--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -9,22 +9,12 @@ jobs:
   docbox:
     name: Generate API Docs
     runs-on: ubuntu-latest
+    container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 11
-          
-      - name: Setup CommandBox
-        uses: Ortus-Solutions/setup-commandbox@v1.0.0
 
       - name: Generate API Docs
         run: box run-script generateAPIDocs

--- a/.github/workflows/docbox.yml
+++ b/.github/workflows/docbox.yml
@@ -9,12 +9,22 @@ jobs:
   docbox:
     name: Generate API Docs
     runs-on: ubuntu-latest
-    container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+          
+      - name: Setup CommandBox
+        uses: Ortus-Solutions/setup-commandbox@v1.0.0
 
       - name: Generate API Docs
         run: box run-script generateAPIDocs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,23 +95,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: box semantic-release
-
-      - name: Generate API Docs
-        run: |
-          box install commandbox-docbox
-          box run-script generateAPIDocs
-
-      - name: Get Current Version
-        id: current_version
-        run: echo "::set-output name=version::`cat box.json | jq '.version' -r`"
-
-      - name: Upload API Docs to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read
-        env:
-          AWS_S3_BUCKET: "apidocs.ortussolutions.com"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET }}
-          SOURCE_DIR: ".tmp/apidocs"
-          DEST_DIR: "${{ github.repository }}/${{ steps.current_version.outputs.version }}"


### PR DESCRIPTION
Brings the API Docs generation task into 2022 :calendar: 

* Declutters the PR workflow :wastebasket: 
* Intros a new, simplified standalone DocBox workflow :package: 
* Builds API docs upon publishing a new Github release :trophy:  
* Example run: https://github.com/michaelborn/unleashsdk/actions/runs/1818246976